### PR TITLE
fix(stitch): size workers_per_gpu by actual band size, not hardcoded 18 GB

### DIFF
--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -1609,8 +1609,12 @@ def stitch(
         t_phase2 = time.time()
 
         # Detect available GPUs and scale workers across all devices.
-        # Peak ~15GB GPU per worker (numer+denom+tile temps in float16).
-        # Use 18GB divisor per device: A100-80GB→4/gpu, H200-141GB→7/gpu, A40-48GB→2/gpu.
+        # Peak GPU per worker depends on band size: numer + denom + norm temp
+        # + block + working ≈ 4 × (T*C*Z × ty_band × total_x × itemsize). For
+        # track/pheno T*C*Z ~5-10 → ~10-15 GB; for ISS T*C*Z ~50-70 → ~20-25 GB.
+        # We compute peak from the actual work queue (max final_shape across
+        # wells) so packing is correct for the real dataset rather than a
+        # hardcoded 18 GB divisor.
         from ops_utils.hpc.gpu_utils import _setup_gpu_environment
         from ops_utils.hpc.parallel_utils import MultiGPUCluster
         available_gpus = _setup_gpu_environment()
@@ -1620,9 +1624,27 @@ def stitch(
             # Query per-device VRAM from the first visible GPU
             per_gpu_mb = xp.cuda.Device(0).mem_info[1]
             per_gpu_gb = per_gpu_mb / 1e9
-            workers_per_gpu = max(1, int(per_gpu_gb // 18))
+
+            # Peak band size across the whole work_queue: each item carries
+            # final_shape; band height is at most ty_band; band width is the
+            # full stitched x extent (final_shape[-1]).
+            itemsize = int(np.dtype(dtype_val).itemsize)
+            peak_band_bytes = 0
+            for _wid, _bidx, _y0, _y1, _yts, _fshape, _is_last in work_queue:
+                t_c_z = int(_fshape[0]) * int(_fshape[1]) * int(_fshape[2])
+                band_h = int(min(ty_band, _fshape[-2] - _y0))
+                band_w = int(_fshape[-1])
+                array_bytes = t_c_z * band_h * band_w * itemsize
+                if array_bytes > peak_band_bytes:
+                    peak_band_bytes = array_bytes
+            # Per-worker peak: numer + denom + norm + block/working ≈ 4×.
+            # Add 4 GB headroom for cuda context, cupy memory-pool overhead,
+            # and the prefetched-tile cache.
+            peak_gb_per_worker = (4 * peak_band_bytes) / 1e9 + 4.0
+            workers_per_gpu = max(1, int(per_gpu_gb // peak_gb_per_worker))
             n_dask_workers = min(workers_per_gpu * n_gpus, len(work_queue))
-            print(f"[Dask Bands] {n_gpus} GPU(s), {per_gpu_gb:.0f}GB each → "
+            print(f"[Dask Bands] {n_gpus} GPU(s), {per_gpu_gb:.0f}GB each, "
+                  f"peak~{peak_gb_per_worker:.1f}GB/worker → "
                   f"{workers_per_gpu}/gpu × {n_gpus} = {n_dask_workers} workers")
         else:
             workers_per_gpu = min(4, len(work_queue))


### PR DESCRIPTION
## Problem

ISS stitching OOMs even on H200 (140 GB). Reported by Gav on `ops0147_20260422.estimate_and_stitch_iss`:

```
cupy.cuda.memory.OutOfMemoryError: Out of memory allocating 5,602,918,400 bytes
(allocated so far: 11,207,271,424 bytes)

File "stitching/stitch/stitch/assemble.py", line 264, in _process_y_band_gpu
    numer = xp.zeros(...)
```

(The same log has cupy `overflow encountered in cast` warnings — unrelated noise from a sibling worker that didn't OOM.)

## Root cause

`_stitch_bands` sizes worker concurrency with a hardcoded divisor:

```python
workers_per_gpu = max(1, int(per_gpu_gb // 18))
```

That 18 GB was calibrated for track/pheno datasets where `T*C*Z` (the leading 3 dims of `final_shape`) is small (~5-10) so the per-worker peak `numer + denom + norm + working` is roughly 15 GB.

ISS stacks cycles × channels into the leading dims, giving `T*C*Z` ≈ 50-70. The same band size and chunk geometry then yields ~22-28 GB per worker. The 18 GB divisor still hands out:
- **8 workers/H200** (150 GB) → 8 × 22 GB ≈ 176 GB → OOM
- 4 workers/H100 (80 GB) → 4 × 22 ≈ 88 GB → mostly fits, occasional fragmentation OOM
- 2 workers/A100-40 → ~44 GB → OOM

## Fix

Compute peak band size from the actual work queue's `final_shape` (max across wells), multiply by 4 to cover `numer + denom + norm + block/working`, add 4 GB for CUDA context, cupy memory pool fragmentation, and the prefetched-tile cache. Divide GPU VRAM by that.

```python
itemsize = int(np.dtype(dtype_val).itemsize)
peak_band_bytes = max(
    int(_fshape[0]*_fshape[1]*_fshape[2]) * min(ty_band, _fshape[-2]-_y0) * _fshape[-1] * itemsize
    for _wid, _bidx, _y0, _y1, _yts, _fshape, _is_last in work_queue
)
peak_gb_per_worker = (4 * peak_band_bytes) / 1e9 + 4.0
workers_per_gpu = max(1, int(per_gpu_gb // peak_gb_per_worker))
```

## A/B validation

Tested on the same `ops0147_20260422` ISS dataset that Gav ran. Used `assemble.stitch()` directly with the production `stitch_settings.yml` so we exercise the exact failure code path (the OOM is in stitch, not in `estimate_stitch`).

| Run | GPU | Code | workers_per_gpu | Wall | OOMs | Result |
|---|---|---|---:|---:|---:|---|
| A | H100 (80GB) | origin/main | 4 | 3:35 | 1 (recovered via retry) | ✓ lucky |
| B | H100 (80GB) | this PR | 3 | 3:53 | 0 | ✓ clean |
| **A2** | **H200 (150GB)** | **origin/main** | **8** | **15:21** | **6, 1 perm** | ✗ **FAILED** (Gav's case) |
| **B2** | **H200 (150GB)** | **this PR** | **5** | **2:59** | **0** | ✓ **clean** |

The fix turns the 15:21 H200 failure into a 2:59 success — **5× faster AND no failure**. Even more striking: B2 on H200 is 22% faster than B on H100, because once we're not over-subscribing the GPU, extra VRAM-headroom isn't wasted on contention.

Track/pheno still get high concurrency since their peak band is ~0.4 GB:
- H200: 25+ workers (capped by `len(work_queue)`)
- H100: 14+ workers
- A100-40: 7+ workers

## Why H200 was slower than H100 in the old code

`per-band` timings on H200 (8 workers) vs H100 (3 workers, fix):

```
H100 fix: total=16-17s   gpu=5s   d2h=1.5s   wait_prev=8s
H200 old: total=36-83s   gpu=10-40s   d2h=12-32s   wait_prev=0-20s
```

Three causes that compound when oversubscribed:
1. **GPU kernel-launch contention** — multiple worker CUDA contexts serialize on the device.
2. **PCIe Gen5 ×16 (~63 GB/s) is the same on both cards** — 8 workers each doing 5.6 GB D2H ≈ 45 GB total / 63 GB/s = 0.7 s ideal, observed 12-32 s under contention.
3. **NFS write congestion** — 8 simultaneous writers split the same shared bandwidth.

## Test plan

- [x] Module import + AST parse OK
- [x] H100 baseline (origin/main) reproduces transient OOM, recovers
- [x] H100 fix runs clean, 0 OOMs
- [x] **H200 baseline (origin/main) reproduces Gav's failure mode exactly** — same `RuntimeError: Failed to process N bands` after 2 retries, same allocation pattern (`5.6 GB attempted, 11.2 GB already allocated`)
- [x] **H200 fix runs clean, 0 OOMs, 5× faster** (2:59 vs 15:21)
- [ ] Reviewer: spot-check that track/pheno timing is unchanged or improved (more concurrency, same per-band peak, more headroom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)