### PR TITLE
perf: v3-native pheno stitch — ~9× faster end-to-end, eliminates convert_v3

### DIFF
--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -2191,6 +2191,37 @@ def _stitch_bands_loop_worker(
     return results
 
 
+def _write_v3_channels_metadata(
+    output_store_path: str, channel_names: list, experiment: str | None
+):
+    """Mirror convert_v3's plate-root channels_metadata block.
+
+    Must run AFTER iohub's output_store.close(). Writing while the iohub
+    plate is still open gets clobbered when subsequent create_position()
+    calls flush their cached attrs back to disk. Same pattern as
+    convert_v3.copy_zarrv2_to_zarrv3 (zarr.open r+ then attrs.update).
+    Best-effort — non-fatal on failure.
+    """
+    try:
+        from ops_analysis.processes.convert_v3 import build_channels_metadata
+    except Exception as e:
+        print(f"[v3-native] WARN: build_channels_metadata import failed ({e})")
+        return
+    try:
+        cm = build_channels_metadata(channel_names, experiment=experiment)
+        if not cm:
+            return
+        root = zarr.open(str(output_store_path), mode="r+")
+        existing = dict(root.attrs)
+        existing["channels_metadata"] = cm
+        root.attrs.update(existing)
+        print(
+            f"[v3-native] wrote channels_metadata for {len(cm)} channels to plate root"
+        )
+    except Exception as e:
+        print(f"[v3-native] WARN: could not write channels_metadata ({e})")
+
+
 def stitch(
     config_path: str,
     input_store_path: str,
@@ -2310,23 +2341,10 @@ def stitch(
     )
     print(f"output store created (zarr_version={zarr_version})")
 
-    # When v3-native, mirror initialize_v3_store's channels_metadata zattrs so
-    # downstream tools (zarr_inspector_data, napari) see the same plate-level
-    # metadata they'd see after run_v3_conversion. Best-effort — failures here
-    # are non-fatal because the conversion script's metadata helper isn't
-    # always importable from the stitch submodule.
-    if use_v3_native:
-        try:
-            from ops_analysis.processes.convert_v3 import build_channels_metadata
-            cm = build_channels_metadata(channel_names, experiment=kwargs.get("experiment"))
-            if cm:
-                root = zarr.open(str(output_store_path), mode="r+")
-                attrs = dict(root.attrs)
-                attrs["channels_metadata"] = cm
-                root.attrs.update(attrs)
-                print(f"[v3-native] wrote channels_metadata for {len(cm)} channels to plate root")
-        except Exception as e:
-            print(f"[v3-native] WARN: could not write channels_metadata ({e})")
+    # NOTE: channels_metadata is written at the END of stitch() (after all
+    # output_store writes are complete) — see _write_v3_channels_metadata.
+    # Writing it here gets clobbered when iohub flushes plate-root attrs on
+    # subsequent create_position calls and close().
 
     # Determine parallelization strategy based on parallel_mode and hardware
     use_dask_wells = False
@@ -3023,6 +3041,11 @@ def stitch(
             raise RuntimeError(f"Failed to process {len(failed_wells)} wells: {failed_wells}")
 
         print(f"[Sequential Wells] All {num_wells} wells processed successfully!")
+
+    if use_v3_native:
+        _write_v3_channels_metadata(
+            output_store_path, channel_names, kwargs.get("experiment")
+        )
 
     return
 

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -264,7 +264,15 @@ def _maybe_wrap_for_tensorstore(arr_obj, stitched_pos=None):
         # during commit on a 32-core allocation. Env-var tunable.
         _ts_dc = int(os.environ.get("STITCH_TS_DATA_COPY_CONCURRENCY", "32"))
         _ts_io = int(os.environ.get("STITCH_TS_FILE_IO_CONCURRENCY", "16"))
+        # Bound the cache pool. Default tensorstore cache pool is unbounded
+        # and stores decoded shards/chunks. For a write-heavy workload like
+        # stitch we don't benefit from a big read cache — bounding it lets
+        # us fit more workers in the SLURM memory budget. 2 GB default is
+        # enough for tensorstore's internal scratch without growing
+        # unbounded across the run.
+        _ts_cache = int(os.environ.get("STITCH_TS_CACHE_BYTES", str(2 * 1024**3)))
         ts_context = ts.Context({
+            "cache_pool": {"total_bytes_limit": _ts_cache},
             "data_copy_concurrency": {"limit": _ts_dc},
             "file_io_concurrency": {"limit": _ts_io},
         })
@@ -925,7 +933,14 @@ def _load_band_tiles(y_tiles, store_path, flipud, fliplr, rot90,
                     entry = existing
         return tile_name, entry
 
-    with ThreadPoolExecutor(max_workers=min(16, len(y_tiles))) as loader:
+    # Inner per-band tile-load thread pool. Default 16 is fine for a
+    # single-process run, but with N concurrent shard-stripe workers the
+    # aggregate NFS fanout (N × outer prefetch × 16) wedges the NFS mount
+    # ("D"-state stuck workers, observed in organelle step too). Tunable
+    # via STITCH_INNER_LOAD_THREADS — workers default to 4 to keep total
+    # concurrent NFS reads ~bounded.
+    _inner_max = int(os.environ.get("STITCH_INNER_LOAD_THREADS", "16"))
+    with ThreadPoolExecutor(max_workers=min(_inner_max, len(y_tiles))) as loader:
         futures = [loader.submit(_load_single, m) for m in y_tiles]
         for future in as_completed(futures):
             name, data = future.result()
@@ -1697,6 +1712,33 @@ def _process_stripe_subprocess_entry(args):
     # warm-pool optimisation hoards memory per-process and fragments the
     # device across N workers).
     _os.environ["STITCH_FREE_POOL_PER_BAND"] = "1"
+    # NFS fanout limit: N workers × outer prefetch × inner per-band loaders
+    # easily reaches 500+ concurrent reads, which wedges the NFS mount
+    # (workers stick in "D"-state, same failure mode as organelle Pass 1).
+    # Cap per-worker NFS concurrency so total stays within ~64-128.
+    # Caller can override by setting these env vars themselves.
+    _os.environ.setdefault("STITCH_PIPELINE_WORKERS", "2")
+    _os.environ.setdefault("STITCH_PREFETCH_DEPTH", "2")
+    _os.environ.setdefault("STITCH_INNER_LOAD_THREADS", "4")
+    # Auto-size tensorstore thread pools to match the per-worker share of
+    # the SLURM core allocation. Without this, each worker opens a 32-thread
+    # data_copy + 16-thread file_io pool — N workers all running commit
+    # simultaneously oversubscribes the cgroup (4×48=192 CPU-bound threads
+    # on 32 cores → context-switch + cache thrash). Total budget ≈ allocated
+    # cores; per-worker = cores / N. Operators can still override the env.
+    try:
+        n_w = int(_os.environ.get("STITCH_STRIPE_WORKERS", "4"))
+        n_cpus = int(_os.environ.get(
+            "SLURM_CPUS_PER_TASK",
+            _os.environ.get("OMP_NUM_THREADS_TOTAL", "32"),
+        ))
+        per_worker = max(2, n_cpus // max(1, n_w))
+        _os.environ.setdefault("STITCH_TS_DATA_COPY_CONCURRENCY", str(per_worker))
+        _os.environ.setdefault(
+            "STITCH_TS_FILE_IO_CONCURRENCY", str(max(2, per_worker // 2))
+        )
+    except Exception:
+        pass
     import zarr as _zarr
     from stitch.stitch.assemble import assemble_streaming as _assemble
 

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -1707,11 +1707,15 @@ def _process_stripe_subprocess_entry(args):
      chunks_size, scale, env_vars) = args
     for k, v in env_vars.items():
         _os.environ[k] = v
-    # Many workers share one GPU under shard_stripes. Force the per-band
-    # CuPy pool free so siblings can claim freed VRAM (otherwise the
-    # warm-pool optimisation hoards memory per-process and fragments the
-    # device across N workers).
-    _os.environ["STITCH_FREE_POOL_PER_BAND"] = "1"
+    # NOTE: previously this line forced STITCH_FREE_POOL_PER_BAND=1 across
+    # workers under the rationale that "siblings need freed VRAM" — but
+    # measured: pool-free per band costs 200-800ms of alloc per band per
+    # worker, compounding to 50-150s of regression across a full real-bench
+    # run. With shard_stripes on H100/H200, GPU VRAM is plentiful relative
+    # to per-worker working set (~5 GB × N workers ≪ device VRAM), so the
+    # warm-pool optimisation should remain on. Operators can opt back into
+    # eager freeing via STITCH_FREE_POOL_PER_BAND=1 if running on a much
+    # tighter GPU.
     # NFS fanout limit: N workers × outer prefetch × inner per-band loaders
     # easily reaches 500+ concurrent reads, which wedges the NFS mount
     # (workers stick in "D"-state, same failure mode as organelle Pass 1).

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -64,6 +64,16 @@ _blosc_benchmark_done = False
 from ops_utils.profiling.proc_monitor import start_monitor as _start_cpu_monitor
 
 
+def _v3_shards_attr(stitched_pos):
+    """Return the v3 shards_ratio that the outer stitch() set on this
+    position (None if the output is v2). This lets the assembly inner
+    functions pass shards_ratio to create_zeros without us having to
+    thread a parameter through every layer of the call chain — the outer
+    stitch() function tags each position right after it creates them.
+    """
+    return getattr(stitched_pos, "_v3_shards_ratio", None)
+
+
 def _init_band_write_pool(max_workers=8):
     """Get or create the persistent write thread pool for this worker process."""
     global _band_write_pool
@@ -942,8 +952,9 @@ def assemble_streaming(
     # Create output array on disk only (no auxiliary arrays)
     if arr_out is None:
         try:
-            stitched_pos.create_zeros(
-                "0",
+            v3_shards = _v3_shards_attr(stitched_pos)
+            create_kwargs = dict(
+                name="0",
                 shape=final_shape,
                 chunks=chunks_size,
                 dtype=dtype_val,
@@ -953,6 +964,9 @@ def assemble_streaming(
                     else None
                 ),
             )
+            if v3_shards is not None:
+                create_kwargs["shards_ratio"] = v3_shards
+            stitched_pos.create_zeros(**create_kwargs)
         except Exception:
             pass
 
@@ -1232,6 +1246,12 @@ def _process_single_well(well_id, shifts, output_store, input_store_path, tile_s
         # Thread-safe creation of stitched position
         with well_lock:
             stitched_pos = output_store.create_position("A", well_id, "0")
+            # Propagate v3 shards_ratio (if any) so downstream create_zeros calls
+            # write v3-formatted arrays. Tagged on the position because the inner
+            # functions don't know about it otherwise.
+            v3_shards = kwargs.get("v3_shards_ratio")
+            if v3_shards is not None:
+                stitched_pos._v3_shards_ratio = v3_shards
 
         # Process well (this is where GPU computation happens)
         assemble_streaming(
@@ -1684,10 +1704,57 @@ def stitch(
             pass
 
     # initialize output zarr store
+    # zarr_version controls the on-disk format: "0.4" for OME-Zarr v0.4 (zarr v2),
+    # "0.5" for OME-Zarr v0.5 (zarr v3 with sharding). Default keeps v2 behavior;
+    # callers opt in to v3-native by passing zarr_version="0.5". When v3 is on we
+    # also compute the channel-aware shard ratio (matches the standalone
+    # convert_v3 script's `calculate_channel_based_shards`) so a single-pass
+    # stitcher produces stores byte-equivalent to "v2 stitch + v3 conversion".
+    zarr_version = kwargs.get("zarr_version", "0.4")
+    if zarr_version not in ("0.4", "0.5"):
+        raise ValueError(f"zarr_version must be '0.4' or '0.5', got {zarr_version!r}")
+    use_v3_native = zarr_version == "0.5"
+
+    if use_v3_native:
+        # Channel-aware sharding to match convert_v3's recipe: one shard ≈ 1 GB,
+        # group all channels per shard, square spatial sharding for the rest.
+        # Same formula as ops_process/.../convert_v3.calculate_channel_based_shards.
+        n_ch = len(channel_names)
+        target_chunks_per_shard = 4096
+        spatial_shard_ratio = max(1, int((target_chunks_per_shard / n_ch) ** 0.5))
+        v3_native_shards_ratio = (1, n_ch, 1, spatial_shard_ratio, spatial_shard_ratio)
+        # Make the shards_ratio visible to all inner functions via kwargs —
+        # _process_single_well and the dask-bands path both read this key.
+        kwargs["v3_shards_ratio"] = v3_native_shards_ratio
+        print(f"[v3-native] channel-aware shards_ratio={v3_native_shards_ratio} "
+              f"(channels={n_ch}, target_chunks_per_shard={target_chunks_per_shard})")
+    else:
+        v3_native_shards_ratio = None
+
     output_store = open_ome_zarr(
-        output_store_path, layout="hcs", mode="w-", channel_names=channel_names
+        output_store_path, layout="hcs", mode="w-",
+        channel_names=channel_names,
+        version=zarr_version,
     )
-    print("output store created")
+    print(f"output store created (zarr_version={zarr_version})")
+
+    # When v3-native, mirror initialize_v3_store's channels_metadata zattrs so
+    # downstream tools (zarr_inspector_data, napari) see the same plate-level
+    # metadata they'd see after run_v3_conversion. Best-effort — failures here
+    # are non-fatal because the conversion script's metadata helper isn't
+    # always importable from the stitch submodule.
+    if use_v3_native:
+        try:
+            from ops_analysis.processes.convert_v3 import build_channels_metadata
+            cm = build_channels_metadata(channel_names, experiment=kwargs.get("experiment"))
+            if cm:
+                root = zarr.open(str(output_store_path), mode="r+")
+                attrs = dict(root.attrs)
+                attrs["channels_metadata"] = cm
+                root.attrs.update(attrs)
+                print(f"[v3-native] wrote channels_metadata for {len(cm)} channels to plate root")
+        except Exception as e:
+            print(f"[v3-native] WARN: could not write channels_metadata ({e})")
 
     # Determine parallelization strategy based on parallel_mode and hardware
     use_dask_wells = False
@@ -1753,15 +1820,20 @@ def stitch(
             ty_band, tx_write = int(divide_tile_yx[0]), int(divide_tile_yx[1])
 
         chunk_tc = int(os.environ.get("STITCH_CHUNK_TC", "0") or "0") == 1
+        # Two ways to enable v3 sharding in the Dask-bands path:
+        #  - kwargs["v3_shards_ratio"]: outer stitch() set this when zarr_version="0.5"
+        #  - STITCH_SHARD_RATIO_YX env var: legacy escape hatch for v2-plate experiments
+        v3_shards_ratio_kw = kwargs.get("v3_shards_ratio")
         shard_ratio_yx = int(os.environ.get("STITCH_SHARD_RATIO_YX", "0") or "0")
-        use_v3_shards = shard_ratio_yx > 0
+        use_v3_shards = (v3_shards_ratio_kw is not None) or (shard_ratio_yx > 0)
 
         # chunks_size will be finalised per-well (needs T,C,Z from final_shape).
         blending_exponent = kwargs.get("blending_exponent", 1.0)
         value_precision_bits = kwargs.get("value_precision_bits", 32)
         dtype_val = _resolve_value_dtype(value_precision_bits)
         print(f"[Dask Bands] chunks layout: tile_yx={ty_band} chunk_tc={chunk_tc} "
-              f"shard_ratio_yx={shard_ratio_yx} v3={use_v3_shards}")
+              f"v3_shards_ratio_kw={v3_shards_ratio_kw} "
+              f"shard_ratio_yx_env={shard_ratio_yx} v3={use_v3_shards}")
 
         # Phase 1: Pre-create wells, compute Y-bands, build interleaved work queue
         work_queue = []
@@ -1787,25 +1859,40 @@ def stitch(
 
             stitched_pos = output_store.create_position("A", well_id, "0")
             if use_v3_shards:
-                # iohub.create_zeros() doesn't accept shards; drop down to the
-                # underlying zarr group and use create_array directly. This
-                # bypasses iohub's NGFF metadata helpers — we add a minimal
-                # multiscale entry afterwards if scale was requested.
-                inner_yx = max(1, ty_band // shard_ratio_yx)
-                v3_chunks = (1, 1, 1, inner_yx, inner_yx)
-                v3_shards = (tc_chunk[0], tc_chunk[1], 1, ty_band, tx_write)
-                pos_grp = stitched_pos.zgroup  # underlying zarr group
-                pos_grp.create_array(
+                # Prefer the channel-aware shards_ratio that outer stitch()
+                # computed (v3-native path). Fall back to the env-var formula
+                # for legacy users still passing STITCH_SHARD_RATIO_YX.
+                if v3_shards_ratio_kw is not None:
+                    v3_shards = tuple(v3_shards_ratio_kw)
+                    # Derive chunks from shards: chunks_per_shard ≈ shards_ratio,
+                    # so inner spatial chunk = shard_yx // shard_ratio_yx (=1 for
+                    # the channel-aware case, but generalises if outer wants 2x2).
+                    v3_chunks = (1, 1, 1, ty_band // v3_shards[3] if v3_shards[3] else ty_band,
+                                 tx_write // v3_shards[4] if v3_shards[4] else tx_write)
+                else:
+                    inner_yx = max(1, ty_band // shard_ratio_yx)
+                    v3_chunks = (1, 1, 1, inner_yx, inner_yx)
+                    v3_shards = (tc_chunk[0], tc_chunk[1], 1, ty_band, tx_write)
+
+                # Use iohub create_zeros (it accepts shards_ratio in modern
+                # iohub) so multiscales/transform metadata is written by the
+                # NGFF helper and zarr_inspector_data sees a fully-formed
+                # OME-Zarr v0.5 array.
+                stitched_pos.create_zeros(
                     "0",
                     shape=final_shape,
-                    dtype=dtype_val,
                     chunks=v3_chunks,
-                    shards=v3_shards,
-                    fill_value=0,
+                    shards_ratio=v3_shards,
+                    dtype=dtype_val,
+                    transform=(
+                        [TransformationMeta(type="scale", scale=scale)]
+                        if scale is not None
+                        else None
+                    ),
                 )
                 if well_id == well_ids[0]:
                     print(f"[Dask Bands] zarr v3 layout: chunks={v3_chunks} "
-                          f"shards={v3_shards}")
+                          f"shards_ratio={v3_shards}")
             else:
                 stitched_pos.create_zeros(
                     "0",

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -1154,6 +1154,7 @@ def assemble_streaming(
     per_channel_edt: bool = True,
     parallel_y_bands: bool = False,
     n_workers: Optional[int] = None,
+    y_range: Optional[Tuple[int, int]] = None,
 ):
     """Streamed assembly that avoids saving auxiliary arrays.
 
@@ -1286,16 +1287,35 @@ def assemble_streaming(
     ty, tx = divide_tile_size if divide_tile_size is not None else (1024, 1024)
     total_y, total_x = final_shape[-2], final_shape[-1]
 
-    # Pre-identify all Y-bands and their tiles for batch loading
+    # Pre-identify all Y-bands and their tiles for batch loading.
+    # When y_range=(ys_lo, ys_hi) is set (shard-stripe parallelism), only
+    # bands fully inside the requested Y range are emitted. Band starts
+    # remain on chunk-aligned multiples of ty so stripe boundaries that
+    # are also chunk-aligned (e.g. shard cell heights = 14*1024) cleanly
+    # partition the work.
     y_bands = []
-    for y0 in range(0, total_y, ty):
-        y1 = min(total_y, y0 + ty)
+    if y_range is not None:
+        y_lo, y_hi = y_range
+        y_lo = max(0, int(y_lo))
+        y_hi = min(int(total_y), int(y_hi))
+    else:
+        y_lo, y_hi = 0, total_y
+    # Snap loop start to a multiple of ty so chunk-aligned stripes pick up
+    # only the bands fully inside their range.
+    start = (y_lo // ty) * ty
+    for y0 in range(start, y_hi, ty):
+        if y0 < y_lo:
+            continue
+        y1 = min(y_hi, y0 + ty)
         y_tiles = [
             (nm, t_end, c_end, z_end, ys, ye, xs, xe)
             for (nm, t_end, c_end, z_end, ys, ye, xs, xe) in tile_meta
             if not (ye <= y0 or ys >= y1)
         ]
         y_bands.append((y0, y1, y_tiles))
+    if not y_bands:
+        print(f"[assemble.streaming] No bands in y_range={y_range}; nothing to do")
+        return arr_out
 
     # Pipeline: prefetch multiple Y-bands ahead so tiles are ready when GPU needs them.
     # On 32-CPU production nodes NFS-bound tile reads benefit from more concurrency.
@@ -1649,6 +1669,78 @@ def _process_well_subprocess_entry(args):
         print(f"[Process Wells] Worker for well {well_id} failed: {e}")
         traceback.print_exc()
         return well_id, False
+
+
+def _process_stripe_subprocess_entry(args):
+    """Module-level entry for ``parallel_mode='shard_stripes'``.
+
+    Each task processes a horizontal Y-stripe of one well. Multiple
+    stripes can run concurrently on separate Python processes, so:
+      - Tile reads are partitioned (each worker only loads tiles
+        overlapping its stripe → ~1/N NFS read traffic per worker).
+      - Output writes are partitioned by Y range → workers never write
+        to the same shard rows → independent tensorstore commits.
+      - Memory per worker scales with stripe size, not well size.
+
+    Args is a tuple of pickleable values. The output array is assumed
+    to already be created by the parent (so workers don't race on
+    create_zeros / plate metadata).
+    """
+    import os as _os
+    (well_id, y_start, y_end, shifts, output_store_path, input_store_path,
+     tile_shape, flipud, fliplr, rot90, kwargs, blending_method,
+     chunks_size, scale, env_vars) = args
+    for k, v in env_vars.items():
+        _os.environ[k] = v
+    # Many workers share one GPU under shard_stripes. Force the per-band
+    # CuPy pool free so siblings can claim freed VRAM (otherwise the
+    # warm-pool optimisation hoards memory per-process and fragments the
+    # device across N workers).
+    _os.environ["STITCH_FREE_POOL_PER_BAND"] = "1"
+    import zarr as _zarr
+    from stitch.stitch.assemble import assemble_streaming as _assemble
+
+    v3_shards = kwargs.get("v3_shards_ratio")
+
+    class _StripePositionStub:
+        """Same interface as iohub Position but reads + writes through
+        raw zarr (workers don't go through iohub). The output array is
+        opened existing — parent already created it."""
+        def __init__(self, group_path):
+            self._group_path = group_path
+            self._v3_shards_ratio = v3_shards
+        def __getitem__(self, key):
+            return _zarr.open(f"{self._group_path}/{key}", mode="r+")
+        def create_zeros(self, *a, **kw):
+            # Output array already exists — parent created it. No-op.
+            pass
+
+    try:
+        group_path = f"{output_store_path}/A/{well_id}/0"
+        stitched_pos = _StripePositionStub(group_path)
+
+        _assemble(
+            shifts=shifts,
+            tile_size=tile_shape[-2:],
+            fov_store_path=input_store_path,
+            stitched_pos=stitched_pos,
+            flipud=flipud, fliplr=fliplr, rot90=rot90,
+            tcz_policy=kwargs.get("tcz_policy", "min"),
+            blending_method=blending_method,
+            blending_exponent=kwargs.get("blending_exponent", 1.0),
+            value_precision_bits=kwargs.get("value_precision_bits", 32),
+            chunks_size=chunks_size,
+            scale=scale,
+            divide_tile_size=kwargs.get("target_chunks_yx", (1024, 1024)),
+            profile=kwargs.get("profile", False),
+            y_range=(y_start, y_end),
+        )
+        return (well_id, y_start, y_end, True)
+    except Exception as e:
+        import traceback
+        print(f"[Stripe] Worker for well {well_id} stripe [{y_start}:{y_end}] failed: {e}")
+        traceback.print_exc()
+        return (well_id, y_start, y_end, False)
 
 
 def _process_single_well(well_id, shifts, output_store, input_store_path, tile_shape,
@@ -2061,7 +2153,7 @@ def stitch(
     fliplr: bool = False,
     rot90: int = 0,
     blending_method: Literal["average", "edt"] = "edt",
-    parallel_mode: Literal["auto", "wells", "wells_threads", "y_bands", "sequential"] = "auto",
+    parallel_mode: Literal["auto", "wells", "wells_threads", "wells_processes", "shard_stripes", "y_bands", "sequential"] = "auto",
     **kwargs,
 ):
     """Mimic of biahub stitch function
@@ -2182,6 +2274,7 @@ def stitch(
     use_dask_wells = False
     use_thread_wells = False
     use_process_wells = False
+    use_stripe_workers = False
     use_parallel_y_bands = False
     n_workers = None
 
@@ -2209,6 +2302,9 @@ def stitch(
     elif parallel_mode == "wells_processes":
         use_process_wells = True
         print("[stitch] Forced multiprocess wells strategy (spawn, true GIL bypass)")
+    elif parallel_mode == "shard_stripes":
+        use_stripe_workers = True
+        print("[stitch] Forced shard-stripe multiprocess strategy")
     elif parallel_mode == "y_bands":
         use_parallel_y_bands = True
         n_workers = _get_optimal_workers(use_gpu=False, verbose=True)
@@ -2699,6 +2795,140 @@ def stitch(
         if failed_wells:
             print(f"[Process Wells] Failed: {len(failed_wells)} wells: {failed_wells}")
             raise RuntimeError(f"Failed to process {len(failed_wells)} wells: {failed_wells}")
+
+    elif use_stripe_workers:
+        # SHARD-STRIPE MULTIPROCESS — partition each well's Y range into
+        # chunk-aligned stripes and run them across a worker pool.
+        # Workers never write to the same shard rows → no commit conflict;
+        # tile reads partition cleanly → much less NFS contention than
+        # whole-well multiprocess; memory per worker scales with stripe
+        # size (smaller buffers per worker = fits more workers in RAM).
+        import multiprocessing as _mp
+        from concurrent.futures import ProcessPoolExecutor as _PPE
+
+        stripes_per_well = max(1, int(os.environ.get("STITCH_STRIPES_PER_WELL", "4")))
+        max_workers_env = int(os.environ.get(
+            "STITCH_STRIPE_WORKERS",
+            str(min(num_wells * stripes_per_well, 6))
+        ))
+        # Pre-create plate, positions, AND output arrays in the parent so
+        # workers don't race on iohub writes. Workers open the array as
+        # raw zarr.
+        for well_id in well_ids:
+            try:
+                pos = output_store.create_position("A", well_id, "0")
+                v3_shards_in = kwargs.get("v3_shards_ratio")
+                if v3_shards_in is not None:
+                    pos._v3_shards_ratio = v3_shards_in
+                # Pre-create the output array so workers can open as r+
+                final_shape = output_store.get_well_final_shape("A", well_id) \
+                    if hasattr(output_store, "get_well_final_shape") else None
+                # Fall back to computing it from the shifts the worker would use.
+                if final_shape is None:
+                    well_shifts = grouped_shifts[well_id]
+                    final_shape_xy = get_output_shape(well_shifts, tile_shape[-2:])
+                    # Match the pattern used inside assemble_streaming
+                    final_shape = (
+                        tile_shape[0], tile_shape[1], tile_shape[2],
+                        final_shape_xy[0], final_shape_xy[1],
+                    )
+                from iohub.ngff import TransformationMeta as _TM
+                create_kwargs = dict(
+                    name="0",
+                    shape=final_shape,
+                    chunks=chunks_size,
+                    dtype=_resolve_value_dtype(kwargs.get("value_precision_bits", 32)),
+                    transform=([_TM(type="scale", scale=scale)] if scale is not None else None),
+                )
+                if v3_shards_in is not None:
+                    wb_y, wb_x = chunks_size[3], chunks_size[4]
+                    rsy = max(1, wb_y // 512); rsx = max(1, wb_x // 512)
+                    create_kwargs["shards_ratio"] = (
+                        v3_shards_in[0], v3_shards_in[1], v3_shards_in[2],
+                        max(1, v3_shards_in[3] // rsy),
+                        max(1, v3_shards_in[4] // rsx),
+                    )
+                try:
+                    pos.create_zeros(**create_kwargs)
+                except Exception as e:
+                    print(f"[Stripes] WARN: pre-create array {well_id} failed: {e}")
+            except Exception as e:
+                print(f"[Stripes] WARN: pre-create position {well_id} failed: {e}")
+        output_store.close()
+        del output_store
+
+        env_to_forward = {
+            k: v for k, v in os.environ.items()
+            if k.startswith("STITCH_") or k.startswith("CUDA_") or k.startswith("OMP_")
+            or k.startswith("MKL_") or k.startswith("OPENBLAS_") or k.startswith("NUMEXPR_")
+        }
+
+        # Build (well, stripe) tasks. CRITICAL: stripe boundaries must
+        # snap to SHARD CELL height, not chunk height. Multiple stripes
+        # writing into the same shard race on commit (each worker has its
+        # own tensorstore Transaction; commits are not coordinated, so
+        # the second commit overwrites the first). Aligning to shard
+        # cells ensures each shard is fully owned by exactly one worker.
+        v3_shards_in = kwargs.get("v3_shards_ratio")
+        ty_band = chunks_size[3]
+        if v3_shards_in is not None:
+            wb_y = chunks_size[3]
+            rsy = max(1, wb_y // 512)
+            shard_ratio_y = max(1, v3_shards_in[3] // rsy)
+            shard_cell_y = ty_band * shard_ratio_y
+        else:
+            shard_cell_y = ty_band
+        all_tasks = []
+        for well_id in well_ids:
+            well_shifts = grouped_shifts[well_id]
+            final_shape_xy = get_output_shape(well_shifts, tile_shape[-2:])
+            total_y_well = int(final_shape_xy[0])
+            # Cap stripes at the number of shard rows available
+            n_shard_rows = max(1, (total_y_well + shard_cell_y - 1) // shard_cell_y)
+            n_stripes_eff = min(stripes_per_well, n_shard_rows)
+            if n_stripes_eff < stripes_per_well:
+                print(f"[Stripes] Capped well {well_id} from {stripes_per_well} to "
+                      f"{n_stripes_eff} stripes (only {n_shard_rows} shard rows)")
+            # Distribute shard rows across stripes. Each stripe owns a
+            # contiguous block of shard rows; last stripe takes any leftover.
+            shards_per_stripe = n_shard_rows // n_stripes_eff
+            cuts = [i * shards_per_stripe * shard_cell_y for i in range(n_stripes_eff)]
+            cuts.append(total_y_well)
+            for y_start, y_end in zip(cuts[:-1], cuts[1:]):
+                if y_end <= y_start:
+                    continue
+                # Pass FULL shifts so assemble_streaming computes the correct
+                # global final_shape. Filtering shifts to "tiles in this
+                # stripe" makes get_output_shape return a smaller total_y,
+                # which in turn clamps y_range and corrupts stripe writes.
+                # The band-vs-tile intersection filter inside the band loop
+                # only loads tiles that actually overlap each band, so
+                # passing full shifts costs little — most tiles outside the
+                # stripe are never loaded.
+                all_tasks.append((
+                    well_id, y_start, y_end, well_shifts, output_store_path,
+                    input_store_path, tile_shape, flipud, fliplr, rot90,
+                    kwargs, blending_method, chunks_size, scale, env_to_forward,
+                ))
+
+        print(f"[Stripes] Dispatching {len(all_tasks)} tasks across {max_workers_env} workers "
+              f"({stripes_per_well} stripes/well × {num_wells} wells)")
+
+        ctx = _mp.get_context("spawn")
+        completed = []
+        failed = []
+        with _PPE(max_workers=max_workers_env, mp_context=ctx) as ex:
+            for result in ex.map(_process_stripe_subprocess_entry, all_tasks):
+                well_id, y_start, y_end, ok = result
+                if ok:
+                    completed.append((well_id, y_start, y_end))
+                else:
+                    failed.append((well_id, y_start, y_end))
+
+        print(f"[Stripes] Completed {len(completed)}/{len(all_tasks)} tasks")
+        if failed:
+            print(f"[Stripes] Failed: {failed}")
+            raise RuntimeError(f"Failed to process {len(failed)} stripes: {failed}")
 
     else:
         # SEQUENTIAL WELL PROCESSING with optional parallel Y-bands

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -2170,10 +2170,22 @@ def stitch(
             - "auto" (default): GPU + Dask uses multiprocess wells, GPU without Dask uses threaded wells, CPU uses parallel Y-bands
             - "wells": Force parallel well processing (Dask multiprocessing if available, else threads)
             - "wells_threads": Force parallel well processing via ThreadPoolExecutor (legacy)
+            - "wells_processes": Force multiprocess wells (spawn)
+            - "shard_stripes": Force shard-stripe multiprocess (recommended for v3-native)
             - "y_bands": Force parallel Y-band processing (joblib)
             - "sequential": No parallelization
         **kwargs: Additional arguments passed to assemble_streaming()
+
+    STITCH_PARALLEL_MODE env var, if set to one of the above values, overrides
+    the parameter — used by production callers that don't take parallel_mode
+    in their own signature (e.g. estimate_and_stitch).
     """
+    # Env-var override so production callers (estimate_and_stitch) can pick
+    # shard_stripes without a signature change.
+    _pm_env = os.environ.get("STITCH_PARALLEL_MODE", "").strip().lower()
+    if _pm_env in ("auto", "wells", "wells_threads", "wells_processes",
+                   "shard_stripes", "y_bands", "sequential"):
+        parallel_mode = _pm_env
 
     # get the shifts and split into a list of lists per well
     all_shifts = read_shifts_biahub(config_path)

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -21,6 +21,36 @@ import threading
 import time
 from joblib import Parallel, delayed
 
+# Optional override of iohub's default zstd codec for v3 outputs.
+# STITCH_V3_CODEC=lz4 → faster encode, larger files.
+# STITCH_V3_CODEC=zstd (default) → iohub default (clevel=1, bitshuffle).
+# STITCH_V3_CODEC=none → no compression, fastest commits, biggest files.
+_v3_codec_env = os.environ.get("STITCH_V3_CODEC", "").strip().lower()
+if _v3_codec_env in ("lz4", "none"):
+    try:
+        import iohub.ngff.nodes as _ngff_nodes
+        import zarr.codecs as _zc
+        _orig_create_compressor_options = _ngff_nodes.Position._create_compressor_options
+
+        def _patched_create_compressor_options(self):
+            shuffle = _zc.BloscShuffle.bitshuffle
+            if self._zarr_format == 3:
+                if _v3_codec_env == "none":
+                    return {"compressors": None}
+                return {
+                    "compressors": _zc.BloscCodec(
+                        cname=_v3_codec_env, clevel=1, shuffle=shuffle,
+                    )
+                }
+            # v2 path unchanged
+            return _orig_create_compressor_options(self)
+
+        _ngff_nodes.Position._create_compressor_options = _patched_create_compressor_options
+        print(f"[v3-codec] Overriding iohub default zstd → {_v3_codec_env}")
+    except Exception as e:
+        print(f"[v3-codec] WARN: failed to patch iohub codec ({e}); using default zstd")
+
+
 try:
     from dask.distributed import LocalCluster, Client
     _DASK_DISTRIBUTED_AVAILABLE = True
@@ -64,6 +94,32 @@ _blosc_benchmark_done = False
 from ops_utils.profiling.proc_monitor import start_monitor as _start_cpu_monitor
 
 
+# Set True while >1 well shares the same GPU (use_thread_wells / use_dask_wells)
+# so per-band cleanup hands blocks back to CUDA and other workers can grab them.
+# In single-well sequential mode we keep the pool warm — alloc cost drops from
+# 300-800ms to ~2-3ms per band (observed in py-spy + STITCH_PROFILE=1).
+_PARALLEL_WELLS_ACTIVE = False
+
+
+def _maybe_free_pool() -> None:
+    """Release CuPy memory-pool blocks back to CUDA driver only when needed.
+
+    Defaults: keep blocks (single-well case = fastest re-allocation).
+    Auto-flips to "free" when parallel wells are sharing one GPU.
+    Override via ``STITCH_FREE_POOL_PER_BAND=1`` (always free) or
+    ``STITCH_FREE_POOL_PER_BAND=0`` (never free, even under parallel wells —
+    only safe if the GPU has headroom for all wells' working sets).
+    """
+    override = os.environ.get("STITCH_FREE_POOL_PER_BAND", "")
+    if override in ("0", "false", "no"):
+        return
+    if override in ("1", "true", "yes") or _PARALLEL_WELLS_ACTIVE:
+        try:
+            xp.get_default_memory_pool().free_all_blocks()
+        except Exception:
+            pass
+
+
 def _v3_shards_attr(stitched_pos):
     """Return the v3 shards_ratio that the outer stitch() set on this
     position (None if the output is v2). This lets the assembly inner
@@ -72,6 +128,177 @@ def _v3_shards_attr(stitched_pos):
     stitch() function tags each position right after it creates them.
     """
     return getattr(stitched_pos, "_v3_shards_ratio", None)
+
+
+class _TensorStoreWriteAdapter:
+    """Adapter that makes a tensorstore-backed array support numpy-style
+    ``arr[slices] = value`` assignment.
+
+    zarr-python 3.1's sharding codec has a path in ``encode_partial`` that
+    silently loses data on certain unaligned slice writes (we observed
+    scattered missing chunks even for nominally aligned writes via
+    ``stitched_pos["0"][...] = block``). The convert_v3 conversion script
+    sidesteps this by routing all writes through tensorstore, whose
+    sharding implementation correctly handles partial-shard
+    read-modify-writes.
+
+    This adapter wraps a tensorstore handle and exposes ``__setitem__`` so
+    the existing stitcher write call sites
+    (``arr_out[(s, s, s, slice(y0,y1), slice(x0,x1))] = norm_cpu``) keep
+    working without invasive changes. ``__getattr__`` and ``shape`` /
+    ``chunks`` attribute pass-through let the rest of the code interact
+    with it like a zarr/iohub array.
+    """
+
+    def __init__(self, ts_array, shape, chunks=None, dtype=None,
+                 use_transaction: bool = True):
+        self._ts = ts_array
+        self.shape = tuple(shape)
+        self.chunks = tuple(chunks) if chunks is not None else None
+        self.dtype = dtype
+        # Sharded v3 writes are catastrophically slow without coalescing:
+        # each X-block write triggers a full shard read-modify-write
+        # (~358ms per write × 2548 writes/well ≈ 970s drain on real bench).
+        # We commit every STITCH_TXN_BAND_GROUP bands (default 8) — staging
+        # ~16 GB per txn — to bound peak memory. Per-WELL txn (1 commit)
+        # OOM'd at 368 GB on real bench; per-BAND txn (52 commits) is
+        # memory-safe but ~80s slower from extra shard re-encodes.
+        self._use_transaction = use_transaction
+        self._txn = None
+        self._pending_commits = []  # in-flight async commits from prior groups
+        self._txn_lock = threading.Lock()
+        # Bands written into the current txn since it was opened.
+        self._band_count_in_txn = 0
+        # Default 999 = act as per-well (single commit at end of well).
+        # Smaller values trade more frequent commits for bounded memory.
+        self._band_group_size = max(1, int(os.environ.get("STITCH_TXN_BAND_GROUP", "999")))
+
+    def begin_band(self):
+        """Lazy-open a Transaction if one isn't already active. Single
+        Transaction batches up to ``_band_group_size`` bands' worth of
+        X-block writes before commit, balancing shard-re-encode count
+        (fewer = better wall) against staged-memory peak (smaller = no OOM)."""
+        if not self._use_transaction:
+            return
+        if self._txn is not None:
+            return
+        try:
+            import tensorstore as _ts
+            with self._txn_lock:
+                if self._txn is None:
+                    self._txn = _ts.Transaction()
+                    self._band_count_in_txn = 0
+        except Exception as e:
+            print(f"[v3-native] WARN: Transaction unavailable ({e}); falling back to non-coalesced writes")
+            self._txn = None
+
+    def end_band_async(self):
+        """Mark a band's writes as staged. Commit and reset the txn when
+        ``_band_group_size`` bands have accumulated, capping memory."""
+        with self._txn_lock:
+            self._band_count_in_txn += 1
+            if self._band_count_in_txn < self._band_group_size:
+                return
+            txn = self._txn
+            self._txn = None
+            self._band_count_in_txn = 0
+        if txn is not None:
+            self._pending_commits.append(txn.commit_async())
+
+    @property
+    def txn_view(self):
+        """Returns the tensorstore handle bound to the open transaction (if
+        any) so writes accumulate before commit."""
+        with self._txn_lock:
+            txn = self._txn
+        if txn is not None:
+            return self._ts.with_transaction(txn)
+        return self._ts
+
+    def __setitem__(self, key, value):
+        self.txn_view[key].write(value).result()
+
+    def __getitem__(self, key):
+        return self.txn_view[key].read().result()
+
+    def commit(self):
+        """Final drain: commit any live txn, then wait on all pending
+        async commits. Called once at end of well.
+
+        In sequential mode this is THE single per-well commit (~4 shard
+        re-encodes). In parallel-wells mode end_band_async has already
+        kicked off per-band commits; this just drains them."""
+        with self._txn_lock:
+            txn = self._txn
+            self._txn = None
+        if txn is not None:
+            # Issue the commit; reuse the same drain loop below.
+            self._pending_commits.append(txn.commit_async())
+        for fut in self._pending_commits:
+            fut.result()
+        self._pending_commits = []
+
+    def __getattr__(self, name):
+        return getattr(self._ts, name)
+
+
+def _maybe_wrap_for_tensorstore(arr_obj, stitched_pos=None):
+    """If ``arr_obj`` is backed by a v3 sharded zarr array (detected via the
+    position's ``_v3_shards_ratio`` tag), return a ``_TensorStoreWriteAdapter``
+    wrapping its tensorstore handle. Otherwise return ``arr_obj`` unchanged.
+
+    Inputs:
+      - ``arr_obj``: an iohub ImageArray or raw zarr Array
+      - ``stitched_pos``: optional iohub Position used to detect v3-sharded mode
+    """
+    use_ts = False
+    if stitched_pos is not None and _v3_shards_attr(stitched_pos) is not None:
+        use_ts = True
+    if not use_ts:
+        return arr_obj
+    try:
+        import tensorstore as ts
+        # Override tensorstore's default thread pools so the commit phase
+        # can saturate our SLURM core allocation. Defaults are small (~4-8
+        # for data_copy_concurrency) and we observed only ~18 cores in use
+        # during commit on a 32-core allocation. Env-var tunable.
+        _ts_dc = int(os.environ.get("STITCH_TS_DATA_COPY_CONCURRENCY", "32"))
+        _ts_io = int(os.environ.get("STITCH_TS_FILE_IO_CONCURRENCY", "16"))
+        ts_context = ts.Context({
+            "data_copy_concurrency": {"limit": _ts_dc},
+            "file_io_concurrency": {"limit": _ts_io},
+        })
+
+        # iohub ImageArray exposes .tensorstore(); raw zarr arrays don't.
+        if hasattr(arr_obj, "tensorstore"):
+            base_ts = arr_obj.tensorstore()
+            # Reopen with our context so concurrency limits apply. The spec
+            # already encodes the storage location and codec.
+            try:
+                ts_array = ts.open(base_ts.spec(), context=ts_context).result()
+            except Exception:
+                ts_array = base_ts  # fall back to iohub's default context
+        else:
+            # For raw zarr v3 arrays, we need to open them via tensorstore
+            # ourselves. The path is reachable via the array's store info.
+            store_root = str(arr_obj.store.root) if hasattr(arr_obj.store, "root") else None
+            arr_path = arr_obj.path  # e.g. "A/1/0/0"
+            if store_root is None:
+                return arr_obj  # can't wrap; fall back to direct writes
+            full_path = f"{store_root}/{arr_path}" if arr_path else store_root
+            ts_array = ts.open({
+                "driver": "zarr3",
+                "kvstore": {"driver": "file", "path": full_path},
+            }, context=ts_context).result()
+        return _TensorStoreWriteAdapter(
+            ts_array,
+            shape=arr_obj.shape,
+            chunks=getattr(arr_obj, "chunks", None),
+            dtype=getattr(arr_obj, "dtype", None),
+        )
+    except Exception as e:
+        print(f"[v3-native] WARN: tensorstore wrap failed ({e}); using direct zarr writes")
+        return arr_obj
 
 
 def _init_band_write_pool(max_workers=8):
@@ -549,15 +776,17 @@ def _process_y_band_gpu(y0, y1, total_x, y_tiles, tile_cache, final_shape,
         timings['slice_cpu'] = t_slice_cpu_total
         timings['h2d'] = t_h2d_total
         timings['gpu_kernel'] = t_gpu_kernel_total
+        timings['num_streams'] = num_streams
         t_norm = time.time()
 
     # Normalize in-place to minimize GPU memory (avoids ~20GB of temporaries)
     xp.maximum(denom, 1e-12, out=denom)
     xp.divide(numer, denom, out=numer)
     del denom
-    # Release CuPy memory pool's hold on denom + tile temporaries.
-    # Reduces GPU footprint from ~15GB to ~7GB before D2H, giving headroom for other workers.
-    xp.get_default_memory_pool().free_all_blocks()
+    # Pool blocks are kept by default for next band's alloc; opt-in via
+    # STITCH_FREE_POOL_PER_BAND=1 for the parallel-wells-per-GPU case
+    # where cross-worker pool fragmentation matters more than alloc cost.
+    _maybe_free_pool()
     xp.nan_to_num(numer, copy=False)
     norm = numer  # just rename, no allocation
 
@@ -604,17 +833,39 @@ def _d2h_and_submit_writes(norm_gpu, transfer_stream, arr_out, final_shape,
         # produced a host accumulator.
         norm_cpu = _to_numpy(norm_gpu)
     del norm_gpu
-    # Release GPU memory immediately so other parallel wells can use it
-    xp.get_default_memory_pool().free_all_blocks()
+    # See _maybe_free_pool: pool blocks kept for next band's alloc by default.
+    _maybe_free_pool()
+
+    # v3-native: open a per-band transaction so X-block writes coalesce
+    # into one re-encode per shard at commit time. Per-band (vs per-well)
+    # bounds memory: a full-well txn staged ~110 GB on real bench and
+    # OOM'd at 413 GB across 3 parallel wells.
+    band_started = False
+    if hasattr(arr_out, "begin_band"):
+        arr_out.begin_band()
+        band_started = True
 
     # Split into X-block chunks for zarr chunk alignment
+    band_write_futures = []
     for x0 in range(0, total_x, tx):
         x1 = min(total_x, x0 + tx)
         block_cpu = norm_cpu[:, :, :, :, x0:x1]
         fut = _write_executor.submit(
             _write_zarr_block, arr_out, final_shape, y0, y1, x0, x1, block_cpu
         )
+        band_write_futures.append(fut)
         _write_futures.append(fut)
+
+    # If we opened a band txn, drain its X-block stages before committing.
+    # Stages are memory ops (cheap; ~1ms per write per the synth bench),
+    # so this drain typically finishes in <100ms even for 52 X-blocks.
+    if band_started:
+        for fut in band_write_futures:
+            fut.result()
+        # commit_async returns immediately; the next band can start GPU
+        # work while the prior commit re-encodes shards in tensorstore's
+        # internal threads. Final drain happens in arr_out.commit().
+        arr_out.end_band_async()
 
 
 def _write_zarr_block(arr_out, final_shape, y0, y1, x0, x1, norm_cpu):
@@ -637,29 +888,50 @@ def _write_zarr_block(arr_out, final_shape, y0, y1, x0, x1, norm_cpu):
     return data_bytes, time.time() - t0
 
 
-def _load_band_tiles(y_tiles, store_path, flipud, fliplr, rot90):
+def _load_band_tiles(y_tiles, store_path, flipud, fliplr, rot90,
+                     well_cache=None, well_cache_lock=None):
     """Load all tiles for a Y-band in parallel, returning a tile_cache dict.
 
     Uses direct zarr array access (bypasses iohub HCS metadata parsing).
     Used for pipelined I/O: loading band N+1 while GPU processes band N.
+
+    When ``well_cache`` is provided, tiles are cached across bands within
+    a well — overlap means each tile would otherwise be re-read 2-3× by
+    adjacent bands. With a 200-px overlap on 2048-px tiles + 1024-px Y-bands,
+    each tile sees roughly 2 bands, so caching halves NFS read volume.
+    The cache is keyed by tile_name; entries hold the augmented numpy
+    array (~80 MB for production 5ch×2048² float32 tiles).
     """
-    tile_cache = {}
+    # Local view of just the tiles needed for this band — returned to caller.
+    band_view = {}
 
     def _load_single(tile_meta):
         tile_name, t_end, c_end, z_end, ys, ye, xs, xe = tile_meta
+        # Cache hit: reuse the already-loaded augmented tile.
+        if well_cache is not None:
+            cached = well_cache.get(tile_name)
+            if cached is not None:
+                return tile_name, cached
         tile_full = zarr.open(str(store_path / tile_name / "0"), mode="r")
-        # Keep tiles on CPU to avoid GPU memory contention between parallel wells.
-        # Tiles are transferred to GPU per-slice during band processing.
         tile_cpu = augment_tile(np.asarray(tile_full), flipud, fliplr, rot90)
-        return tile_name, (tile_cpu, t_end, c_end, z_end, ys, ye, xs, xe)
+        entry = (tile_cpu, t_end, c_end, z_end, ys, ye, xs, xe)
+        if well_cache is not None and well_cache_lock is not None:
+            with well_cache_lock:
+                # Double-checked: another thread may have populated while we read.
+                existing = well_cache.get(tile_name)
+                if existing is None:
+                    well_cache[tile_name] = entry
+                else:
+                    entry = existing
+        return tile_name, entry
 
     with ThreadPoolExecutor(max_workers=min(16, len(y_tiles))) as loader:
         futures = [loader.submit(_load_single, m) for m in y_tiles]
         for future in as_completed(futures):
             name, data = future.result()
-            tile_cache[name] = data
+            band_view[name] = data
 
-    return tile_cache
+    return band_view
 
 
 
@@ -952,7 +1224,7 @@ def assemble_streaming(
     # Create output array on disk only (no auxiliary arrays)
     if arr_out is None:
         try:
-            v3_shards = _v3_shards_attr(stitched_pos)
+            v3_shards_in = _v3_shards_attr(stitched_pos)
             create_kwargs = dict(
                 name="0",
                 shape=final_shape,
@@ -964,7 +1236,21 @@ def assemble_streaming(
                     else None
                 ),
             )
-            if v3_shards is not None:
+            # When v3-sharded, set a chunk-aligned shards_ratio. Writes
+            # go through a tensorstore adapter (see _maybe_wrap_for_tensorstore
+            # below) — convert_v3 does the same and gets correct partial-shard
+            # writes; raw zarr-python's sharding codec silently drops chunks.
+            if v3_shards_in is not None:
+                # Original ratio assumed chunks=(1,1,1,512,512); rescale spatial
+                # dims so that chunks × shards_ratio still gives ~1 GB shards.
+                wb_y, wb_x = chunks_size[3], chunks_size[4]
+                ratio_scale_y = max(1, wb_y // 512)
+                ratio_scale_x = max(1, wb_x // 512)
+                v3_shards = (
+                    v3_shards_in[0], v3_shards_in[1], v3_shards_in[2],
+                    max(1, v3_shards_in[3] // ratio_scale_y),
+                    max(1, v3_shards_in[4] // ratio_scale_x),
+                )
                 create_kwargs["shards_ratio"] = v3_shards
             stitched_pos.create_zeros(**create_kwargs)
         except Exception:
@@ -977,6 +1263,11 @@ def assemble_streaming(
 
     if arr_out is None:
         arr_out = stitched_pos["0"]
+        # If this is a v3-sharded output, route writes through tensorstore
+        # for correct partial-shard handling (zarr-python 3.1's sharding
+        # codec drops chunks on certain unaligned writes; tensorstore's
+        # implementation is what convert_v3 uses and is known correct).
+        arr_out = _maybe_wrap_for_tensorstore(arr_out, stitched_pos=stitched_pos)
     dtype_idx = _resolve_shift_dtype(shifts, tile_size, base_bits=32)
 
     # Precompute tile metadata for fast intersection checks (using cached shapes)
@@ -1007,10 +1298,11 @@ def assemble_streaming(
         y_bands.append((y0, y1, y_tiles))
 
     # Pipeline: prefetch multiple Y-bands ahead so tiles are ready when GPU needs them.
-    # With 2 concurrent loaders and 3-band prefetch, effective loading rate (~3.5s/band)
-    # roughly matches GPU processing rate (~2-3s/band), eliminating most tile-wait stalls.
-    _pipeline_executor = ThreadPoolExecutor(max_workers=2)
-    _prefetch_depth = 3
+    # On 32-CPU production nodes NFS-bound tile reads benefit from more concurrency.
+    # Tuned via STITCH_PIPELINE_WORKERS / STITCH_PREFETCH_DEPTH (defaults: 8, 5).
+    _pl_workers = int(os.environ.get("STITCH_PIPELINE_WORKERS", "8"))
+    _pipeline_executor = ThreadPoolExecutor(max_workers=_pl_workers)
+    _prefetch_depth = int(os.environ.get("STITCH_PREFETCH_DEPTH", "5"))
 
     # Background writer: submit zarr writes to a thread pool so GPU can
     # continue with the next Y-band while chunks are flushed to disk.
@@ -1024,10 +1316,20 @@ def assemble_streaming(
     _transfer_stream = xp.cuda.Stream(non_blocking=True) if _USING_CUPY else None
     _prev_d2h_future = None
 
+    # Per-well tile cache: with overlap (e.g. 200 px on 2048 px tiles +
+    # 1024 px Y-bands) each tile is needed by ~2 adjacent bands. Default
+    # off — empirical runs showed wash-or-regression vs no cache, possibly
+    # because the kernel NFS client cache already deduplicates re-reads.
+    # Set STITCH_TILE_CACHE=1 to enable.
+    _use_tile_cache = os.environ.get("STITCH_TILE_CACHE", "0") in ("1", "true", "yes")
+    _well_tile_cache = {} if _use_tile_cache else None
+    _well_tile_cache_lock = threading.Lock() if _use_tile_cache else None
+
     _load_futures = deque()
     for i in range(min(_prefetch_depth, len(y_bands))):
         _load_futures.append(_pipeline_executor.submit(
-            _load_band_tiles, y_bands[i][2], fov_store_p, flipud, fliplr, rot90
+            _load_band_tiles, y_bands[i][2], fov_store_p, flipud, fliplr, rot90,
+            _well_tile_cache, _well_tile_cache_lock,
         ))
 
     for band_idx, (y0, y1, y_tiles) in enumerate(tqdm(y_bands, desc="Stitching Y")):
@@ -1042,7 +1344,8 @@ def assemble_streaming(
         next_prefetch = band_idx + _prefetch_depth
         if next_prefetch < len(y_bands):
             _load_futures.append(_pipeline_executor.submit(
-                _load_band_tiles, y_bands[next_prefetch][2], fov_store_p, flipud, fliplr, rot90
+                _load_band_tiles, y_bands[next_prefetch][2], fov_store_p, flipud, fliplr, rot90,
+                _well_tile_cache, _well_tile_cache_lock,
             ))
 
         print(f"  [Y-band {band_idx+1}/{len(y_bands)}] Loaded {len(y_tiles)} tiles (waited {t_load_elapsed:.2f}s)")
@@ -1077,15 +1380,20 @@ def assemble_streaming(
                 _write_executor, _write_futures,
             )
 
-            # Release freed GPU memory back to CUDA so other parallel wells
-            # can allocate from it. CuPy's memory pool holds onto freed blocks
-            # by default, which causes OOM when multiple wells share one GPU.
-            xp.get_default_memory_pool().free_all_blocks()
+            # See _maybe_free_pool: pool blocks kept for next band's alloc
+            # by default (saves 300-800ms/band of CUDA driver round-trips).
+            _maybe_free_pool()
 
             if profile:
+                # Break accum down into its CPU-slice / H2D / GPU-kernel components
+                # so we can see which dominates and which is parallelisable.
+                _sl = band_timings.get('slice_cpu', 0) * 1000
+                _h2d = band_timings.get('h2d', 0) * 1000
+                _gk = band_timings.get('gpu_kernel', 0) * 1000
                 print(f"  [Y-band {band_idx+1}/{len(y_bands)}] PROFILE: "
                       f"alloc={band_timings['alloc']*1000:.1f}ms  "
-                      f"accum={band_timings['accum']*1000:.1f}ms ({band_timings['n_tiles_hit']} tiles)  "
+                      f"accum={band_timings['accum']*1000:.1f}ms ({band_timings['n_tiles_hit']} tiles "
+                      f"= slice_cpu {_sl:.0f}ms + h2d {_h2d:.0f}ms + gpu_kernel {_gk:.0f}ms)  "
                       f"norm={band_timings['normalize']*1000:.1f}ms  "
                       f"total={t_process_elapsed:.2f}s (D2H pipelined)")
             else:
@@ -1226,7 +1534,121 @@ def assemble_streaming(
     print(f"  [Write drain] Waited {t_drain_elapsed:.2f}s for {len(_write_futures)} background writes"
           f"{f' ({n_failed} failed)' if n_failed else ''}")
 
+    # v3-native: tensorstore transaction commit. All X-block writes have
+    # staged into the per-position transaction; commit now coalesces them
+    # per-shard (one re-encode per shard, instead of one per X-block).
+    if hasattr(arr_out, "commit"):
+        t_commit_start = time.time()
+        arr_out.commit()
+        print(f"  [Txn commit] {time.time() - t_commit_start:.2f}s "
+              f"(coalesced {len(_write_futures)} writes per shard)")
+
     return arr_out
+
+
+def _process_well_subprocess_entry(args):
+    """Module-level entry point for ``parallel_mode='wells_processes'``.
+
+    Each well runs in its own spawn-spawned Python interpreter — independent
+    CUDA context, independent tensorstore handle, independent tile prefetch
+    pool. CPU-side work and tensorstore commits truly parallel across wells
+    (no GIL). GPU-side work is multiplexed by the CUDA driver across the
+    sibling processes' contexts (effectively time-sliced unless MPS is
+    enabled).
+
+    Args is a tuple so it pickles cleanly across the spawn boundary.
+    """
+    import os as _os
+    (well_id, shifts, output_store_path, input_store_path, tile_shape,
+     flipud, fliplr, rot90, kwargs, blending_method, chunks_size, scale,
+     env_vars) = args
+
+    # Propagate the parent's STITCH_* / CUDA_* env so codec/concurrency
+    # overrides are honoured in the subprocess.
+    for k, v in env_vars.items():
+        _os.environ[k] = v
+
+    # Re-import in subprocess (triggers iohub codec patch on stitch import)
+    from iohub.ngff import open_ome_zarr as _open
+    from stitch.stitch.assemble import assemble_streaming as _assemble
+
+    try:
+        # Bypass iohub entirely in the worker. iohub's r+ mode fails to
+        # populate ``_channel_names`` on Plate, Row, Well, Position
+        # objects (the private attribute the inner navigation code
+        # references), and patching each level is fragile. Instead open
+        # the position's array directly via raw zarr and pass a tiny
+        # stub to assemble_streaming that mimics the only iohub Position
+        # attributes the streaming path actually uses (__getitem__,
+        # create_zeros, _v3_shards_ratio).
+        import zarr as _zarr
+        v3_shards = kwargs.get("v3_shards_ratio")
+
+        class _PositionStub:
+            """Minimal stand-in for an iohub Position. Backed by a raw
+            zarr group at ``A/{well_id}/0``. The output array (``"0"``)
+            is created on demand by assemble_streaming; if it already
+            exists (parent pre-created), create_zeros catches the error
+            and the streaming path falls through to ``self["0"]``."""
+            def __init__(self, group_path):
+                self._group_path = group_path
+                self._group = _zarr.open(group_path, mode="r+")
+                self._v3_shards_ratio = v3_shards
+
+            def __getitem__(self, key):
+                arr_path = f"{self._group_path}/{key}"
+                return _zarr.open(arr_path, mode="r+")
+
+            def create_zeros(self, name, shape, dtype, chunks=None,
+                              shards_ratio=None, transform=None,
+                              check_shape=True):
+                # Match iohub's create_zeros signature. Use raw zarr
+                # to materialise the v3 array. Skip if it already exists.
+                arr_path = f"{self._group_path}/{name}"
+                try:
+                    if shards_ratio is not None:
+                        shards = tuple(c * r for c, r in zip(chunks, shards_ratio))
+                        return _zarr.create_array(
+                            store=arr_path, shape=shape, dtype=dtype,
+                            chunks=chunks, shards=shards,
+                            zarr_format=3, overwrite=False,
+                        )
+                    return _zarr.create_array(
+                        store=arr_path, shape=shape, dtype=dtype,
+                        chunks=chunks, zarr_format=3, overwrite=False,
+                    )
+                except Exception:
+                    # Already exists — assemble_streaming's outer try/except
+                    # handles this case.
+                    pass
+
+        group_path = f"{output_store_path}/A/{well_id}/0"
+        try:
+            stitched_pos = _PositionStub(group_path)
+
+            _assemble(
+                shifts=shifts,
+                tile_size=tile_shape[-2:],
+                fov_store_path=input_store_path,
+                stitched_pos=stitched_pos,
+                flipud=flipud, fliplr=fliplr, rot90=rot90,
+                tcz_policy=kwargs.get("tcz_policy", "min"),
+                blending_method=blending_method,
+                blending_exponent=kwargs.get("blending_exponent", 1.0),
+                value_precision_bits=kwargs.get("value_precision_bits", 32),
+                chunks_size=chunks_size,
+                scale=scale,
+                divide_tile_size=kwargs.get("target_chunks_yx", (1024, 1024)),
+                profile=kwargs.get("profile", False),
+            )
+            return well_id, True
+        except Exception:
+            raise
+    except Exception as e:
+        import traceback
+        print(f"[Process Wells] Worker for well {well_id} failed: {e}")
+        traceback.print_exc()
+        return well_id, False
 
 
 def _process_single_well(well_id, shifts, output_store, input_store_path, tile_shape,
@@ -1759,6 +2181,7 @@ def stitch(
     # Determine parallelization strategy based on parallel_mode and hardware
     use_dask_wells = False
     use_thread_wells = False
+    use_process_wells = False
     use_parallel_y_bands = False
     n_workers = None
 
@@ -1783,6 +2206,9 @@ def stitch(
     elif parallel_mode == "wells_threads":
         use_thread_wells = True
         print("[stitch] Forced threaded wells strategy (legacy)")
+    elif parallel_mode == "wells_processes":
+        use_process_wells = True
+        print("[stitch] Forced multiprocess wells strategy (spawn, true GIL bypass)")
     elif parallel_mode == "y_bands":
         use_parallel_y_bands = True
         n_workers = _get_optimal_workers(use_gpu=False, verbose=True)
@@ -1863,12 +2289,28 @@ def stitch(
                 # computed (v3-native path). Fall back to the env-var formula
                 # for legacy users still passing STITCH_SHARD_RATIO_YX.
                 if v3_shards_ratio_kw is not None:
+                    # Match convert_v3's recipe exactly: chunks=(1,1,1,512,512)
+                    # and shards_ratio computed by calculate_channel_based_shards.
+                    # 512 must evenly divide the write-block dims; we ensure that
+                    # by making ty_band/tx_write multiples of 512 below.
+                    v3_chunks = (1, 1, 1, 512, 512)
                     v3_shards = tuple(v3_shards_ratio_kw)
-                    # Derive chunks from shards: chunks_per_shard ≈ shards_ratio,
-                    # so inner spatial chunk = shard_yx // shard_ratio_yx (=1 for
-                    # the channel-aware case, but generalises if outer wants 2x2).
-                    v3_chunks = (1, 1, 1, ty_band // v3_shards[3] if v3_shards[3] else ty_band,
-                                 tx_write // v3_shards[4] if v3_shards[4] else tx_write)
+                    # Round write block to nearest multiple of 512 so block
+                    # writes align with chunk grid — otherwise sharded writes
+                    # at sub-chunk granularity end up zeroing parts of shards.
+                    if ty_band % 512:
+                        new_ty_band = ((ty_band // 512) or 1) * 512
+                        if well_id == well_ids[0]:
+                            print(f"[v3-native] adjusting ty_band {ty_band} → {new_ty_band} "
+                                  f"to align with chunk size 512")
+                        ty_band = new_ty_band
+                    if tx_write % 512:
+                        new_tx_write = ((tx_write // 512) or 1) * 512
+                        if well_id == well_ids[0]:
+                            print(f"[v3-native] adjusting tx_write {tx_write} → {new_tx_write} "
+                                  f"to align with chunk size 512")
+                        tx_write = new_tx_write
+                    chunks_size = (tc_chunk[0], tc_chunk[1], 1, ty_band, tx_write)
                 else:
                     inner_yx = max(1, ty_band // shard_ratio_yx)
                     v3_chunks = (1, 1, 1, inner_yx, inner_yx)
@@ -2155,7 +2597,12 @@ def stitch(
         print(f"[Dask Bands] All {len(work_queue)} bands processed successfully!")
 
     elif use_thread_wells:
-        # THREADED WELL PROCESSING (legacy fallback) — GIL limits true parallelism
+        # THREADED WELL PROCESSING — wells overlap on the same GPU.
+        # Heavy work releases the GIL: zarr/NFS reads, CuPy kernels, NumPy
+        # ops, tensorstore writes, blosc compression. The "GIL-limited"
+        # legacy comment was conservative; in practice we see good overlap.
+        global _PARALLEL_WELLS_ACTIVE
+        _PARALLEL_WELLS_ACTIVE = True
         well_lock = threading.Lock()
         max_workers = min(4, num_wells)
 
@@ -2193,6 +2640,65 @@ def stitch(
             raise RuntimeError(f"Failed to process {len(failed_wells)} wells: {failed_wells}")
 
         print(f"[Thread Wells] All {num_wells} wells processed successfully!")
+        _PARALLEL_WELLS_ACTIVE = False
+
+    elif use_process_wells:
+        # MULTIPROCESS WELL PROCESSING — separate Python interpreters.
+        # Each well gets its own CUDA context + tensorstore handle. CPU work
+        # truly parallel (no GIL). GPU work multiplexed by the driver.
+        import multiprocessing as _mp
+        from concurrent.futures import ProcessPoolExecutor as _PPE
+
+        print(f"[Process Wells] Processing {num_wells} wells with multiprocess pool")
+        print(f"[Process Wells] Wells: {well_ids}")
+
+        # Pre-create positions in the parent so iohub's plate metadata is
+        # flushed to disk before workers open the store (otherwise iohub's
+        # _detect_layout raises KeyError on a plate without 'plate' attrs).
+        for well_id in well_ids:
+            try:
+                pos = output_store.create_position("A", well_id, "0")
+                v3_shards = kwargs.get("v3_shards_ratio")
+                if v3_shards is not None:
+                    pos._v3_shards_ratio = v3_shards
+            except Exception as e:
+                print(f"[Process Wells] WARN: pre-create position {well_id} failed: {e}")
+
+        # Workers re-open the output store; close the parent's handle.
+        output_store.close()
+        del output_store
+
+        # Forward the env knobs that workers care about.
+        env_to_forward = {
+            k: v for k, v in os.environ.items()
+            if k.startswith("STITCH_") or k.startswith("CUDA_") or k.startswith("OMP_")
+            or k.startswith("MKL_") or k.startswith("OPENBLAS_") or k.startswith("NUMEXPR_")
+        }
+
+        args_list = [
+            (well_id, grouped_shifts[well_id], output_store_path, input_store_path,
+             tile_shape, flipud, fliplr, rot90, kwargs, blending_method,
+             chunks_size, scale, env_to_forward)
+            for well_id in well_ids
+        ]
+
+        ctx = _mp.get_context("spawn")
+        # Cap worker count: more workers ≠ better when contending for one GPU
+        # and one NFS link. STITCH_PROCESS_WELLS_WORKERS overrides default.
+        max_workers = int(os.environ.get("STITCH_PROCESS_WELLS_WORKERS", str(min(num_wells, 4))))
+        completed_wells = []
+        failed_wells = []
+        with _PPE(max_workers=max_workers, mp_context=ctx) as ex:
+            for well_id, ok in ex.map(_process_well_subprocess_entry, args_list):
+                if ok:
+                    completed_wells.append(well_id)
+                else:
+                    failed_wells.append(well_id)
+
+        print(f"[Process Wells] Completed: {len(completed_wells)} wells: {completed_wells}")
+        if failed_wells:
+            print(f"[Process Wells] Failed: {len(failed_wells)} wells: {failed_wells}")
+            raise RuntimeError(f"Failed to process {len(failed_wells)} wells: {failed_wells}")
 
     else:
         # SEQUENTIAL WELL PROCESSING with optional parallel Y-bands

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -1146,6 +1146,50 @@ def assemble(
     return stitched
 
 
+# Thresholds for the NFS-contention warning emitted at the end of each
+# stripe. Tuned against pheno-2d on uncontended NFS:
+#   mean band wait ≈ 1-2s, max ≈ 10-30s, commit ≈ 10-20s, drain ≈ 0-2s.
+# When other tenants saturate the storage backend, mean band wait jumps
+# to 4-5s+, max to 60-90s, and commit to 40-90s.
+_NFS_WARN_BAND_WAIT_MEAN_S = 3.5
+_NFS_WARN_BAND_WAIT_MAX_S = 45.0
+_NFS_WARN_COMMIT_S = 35.0
+_NFS_WARN_DRAIN_S = 10.0
+
+
+def _nfs_warn(band_waits, commit_s, drain_s, n_writes, n_failed):
+    """Emit a single [NFS-CONTENTION] line to stderr when read or write
+    timings exceed the typical-load thresholds. Captured by SLURM stderr
+    + stdout, so post-mortem grep on slurm logs surfaces it cheaply."""
+    import sys
+    if not band_waits and not commit_s:
+        return
+    n = len(band_waits)
+    mean_w = (sum(band_waits) / n) if n else 0.0
+    max_w = max(band_waits) if band_waits else 0.0
+    flagged = []
+    if mean_w >= _NFS_WARN_BAND_WAIT_MEAN_S:
+        flagged.append(f"mean band wait {mean_w:.1f}s >= {_NFS_WARN_BAND_WAIT_MEAN_S}s")
+    if max_w >= _NFS_WARN_BAND_WAIT_MAX_S:
+        flagged.append(f"max band wait {max_w:.1f}s >= {_NFS_WARN_BAND_WAIT_MAX_S}s")
+    if commit_s >= _NFS_WARN_COMMIT_S:
+        flagged.append(f"txn commit {commit_s:.1f}s >= {_NFS_WARN_COMMIT_S}s")
+    if drain_s >= _NFS_WARN_DRAIN_S:
+        flagged.append(f"write drain {drain_s:.1f}s >= {_NFS_WARN_DRAIN_S}s")
+    if n_failed:
+        flagged.append(f"{n_failed} failed background writes")
+    if not flagged:
+        return
+    msg = (
+        f"[NFS-CONTENTION] stripe slowed by storage backend — "
+        + ", ".join(flagged)
+        + f" | bands={n}, writes={n_writes}, mean_wait={mean_w:.2f}s, "
+          f"max_wait={max_w:.2f}s, commit={commit_s:.2f}s, drain={drain_s:.2f}s"
+    )
+    print(msg)
+    print(msg, file=sys.stderr, flush=True)
+
+
 def assemble_streaming(
     shifts: dict,
     tile_size: tuple,
@@ -1367,6 +1411,12 @@ def assemble_streaming(
             _well_tile_cache, _well_tile_cache_lock,
         ))
 
+    # Track per-band wait times so we can emit an NFS-contention warning at
+    # the end of the stripe if reads are slower than the typical baseline.
+    # Pipelined reads should add ~0s to wall when NFS keeps up; multi-second
+    # waits mean the GPU is idling on the prefetch.
+    _band_wait_times: list = []
+
     for band_idx, (y0, y1, y_tiles) in enumerate(tqdm(y_bands, desc="Stitching Y")):
         t_band_start = time.time()
 
@@ -1374,6 +1424,7 @@ def assemble_streaming(
         t_load_start = time.time()
         tile_cache = _load_futures.popleft().result()
         t_load_elapsed = time.time() - t_load_start
+        _band_wait_times.append(t_load_elapsed)
 
         # Keep prefetch pipeline full
         next_prefetch = band_idx + _prefetch_depth
@@ -1572,11 +1623,22 @@ def assemble_streaming(
     # v3-native: tensorstore transaction commit. All X-block writes have
     # staged into the per-position transaction; commit now coalesces them
     # per-shard (one re-encode per shard, instead of one per X-block).
+    commit_elapsed = 0.0
     if hasattr(arr_out, "commit"):
         t_commit_start = time.time()
         arr_out.commit()
-        print(f"  [Txn commit] {time.time() - t_commit_start:.2f}s "
+        commit_elapsed = time.time() - t_commit_start
+        print(f"  [Txn commit] {commit_elapsed:.2f}s "
               f"(coalesced {len(_write_futures)} writes per shard)")
+
+    # NFS-contention summary: typical pheno-2d on uncontended NFS shows
+    # mean per-band wait < 2s and per-stripe commit < 25s. When the NFS
+    # backend is loaded by other tenants (D-state worker, slow Vast/NetApp
+    # responses), waits and commits jump 2-3x. Emit a single line to
+    # stderr when either exceeds threshold so the symptom is searchable
+    # in slurm logs without re-parsing every band line.
+    _nfs_warn(_band_wait_times, commit_elapsed, t_drain_elapsed,
+              len(_write_futures), n_failed)
 
     return arr_out
 

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -2337,7 +2337,15 @@ def stitch(
     n_workers = None
 
     if parallel_mode == "auto":
-        if _USING_CUPY and _DASK_DISTRIBUTED_AVAILABLE:
+        if _USING_CUPY and v3_native_shards_ratio is not None:
+            # v3 sharded outputs benefit most from shard-stripe parallelism:
+            # workers own disjoint shards so commits never conflict, and
+            # tile reads partition cleanly across stripes (1/N NFS load
+            # per worker). 3.5× faster end-to-end on real bench vs the
+            # legacy wells-thread/dask paths.
+            use_stripe_workers = True
+            print("[stitch] Auto mode: GPU + v3 detected, using shard-stripe multiprocess strategy")
+        elif _USING_CUPY and _DASK_DISTRIBUTED_AVAILABLE:
             use_dask_wells = True
             print("[stitch] Auto mode: GPU + Dask detected, using Dask multiprocess wells strategy")
         elif _USING_CUPY:

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -2554,8 +2554,12 @@ def stitch(
                         tx_write = new_tx_write
                     chunks_size = (tc_chunk[0], tc_chunk[1], 1, ty_band, tx_write)
                 else:
-                    inner_yx = max(1, ty_band // shard_ratio_yx)
-                    v3_chunks = (1, 1, 1, inner_yx, inner_yx)
+                    # Legacy STITCH_SHARD_RATIO_YX path. Force inner chunks
+                    # to 512x512 to match the v3-native recipe (Gav's PR
+                    # feedback: labels are 512x512 and pyramid levels 1+
+                    # are 512x512, level 0 should be too). Shard outer
+                    # size is still derived from ty_band/shard_ratio_yx.
+                    v3_chunks = (1, 1, 1, 512, 512)
                     v3_shards = (tc_chunk[0], tc_chunk[1], 1, ty_band, tx_write)
 
                 # Use iohub create_zeros (it accepts shards_ratio in modern

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -2983,21 +2983,28 @@ def stitch(
                         final_shape_xy[0], final_shape_xy[1],
                     )
                 from iohub.ngff import TransformationMeta as _TM
+                # In v3-native mode pin level-0 inner chunks to 512x512 to
+                # match the Dask Bands path, convert_v3's recipe, and the
+                # pyramid levels / labels arrays. Stripe-cut boundaries
+                # still align to the absolute shard size below, derived
+                # from chunks_size, so this only changes the on-disk chunk
+                # granularity inside each shard.
+                v3_chunks_for_create = chunks_size
+                if v3_shards_in is not None:
+                    v3_chunks_for_create = (chunks_size[0], chunks_size[1],
+                                            chunks_size[2], 512, 512)
                 create_kwargs = dict(
                     name="0",
                     shape=final_shape,
-                    chunks=chunks_size,
+                    chunks=v3_chunks_for_create,
                     dtype=_resolve_value_dtype(kwargs.get("value_precision_bits", 32)),
                     transform=([_TM(type="scale", scale=scale)] if scale is not None else None),
                 )
                 if v3_shards_in is not None:
-                    wb_y, wb_x = chunks_size[3], chunks_size[4]
-                    rsy = max(1, wb_y // 512); rsx = max(1, wb_x // 512)
-                    create_kwargs["shards_ratio"] = (
-                        v3_shards_in[0], v3_shards_in[1], v3_shards_in[2],
-                        max(1, v3_shards_in[3] // rsy),
-                        max(1, v3_shards_in[4] // rsx),
-                    )
+                    # shards_ratio is the (outer/inner) ratio; with 512x512
+                    # inner chunks the kwarg from outer stitch() applies
+                    # directly (it was computed assuming 512 chunks).
+                    create_kwargs["shards_ratio"] = tuple(v3_shards_in)
                 try:
                     pos.create_zeros(**create_kwargs)
                 except Exception as e:


### PR DESCRIPTION
## Summary

Replaces the **stitch_v2 + convert_v3** two-step pipeline with a single-pass **v3-native stitch** that writes sharded OME-Zarr v0.5 directly. On a real 3-well 370 GB pheno dataset (ops0146), this drops wall time from **~50 min** to **~270-330 s** — **~9× end-to-end speedup**.

The dominant new mechanism is **shard-stripe parallelism** (\`parallel_mode=\"shard_stripes\"\`): each well's output Y range is partitioned along shard cell boundaries and processed by separate spawn workers. Workers own disjoint shards, so tensorstore commits run truly concurrently and tile reads partition cleanly across workers.

When \`zarr_version=\"0.5\"\`, \`parallel_mode=\"auto\"\` now picks \`shard_stripes\` automatically (paired with ops_process making v3 the default — see companion PRs).

## Real-bench results (ops0146, 3 wells, 370 GB output, single GPU, --mem=450G)

| Config | Wall | Notes |
|---|---|---|
| V2 stitch + convert_v3 | ~3000 s (~50 min) | original path |
| V3 sequential | ~700 s | v3-native, single process |
| V3 + shard_stripes (4 workers) | **~270-330 s** (n=5) | new auto-mode default for v3 |

Bit-identical to V2 on every run (slice-equal True, max abs diff 0.0).

Production-path run via \`estimate_and_stitch --zarr-version 0.5\`:
- 271.30 s wall on gpu-f-2 (H100)
- GPU SM 17.5% avg / 99% max
- CPU ~15.8 cores avg / ~28 peak (45.8% of 32 allocated)
- MaxRSS 411 GB / 450 GB

## What's in this PR

### v3-native single-pass stitch
- \`zarr_version=\"0.5\"\` writes sharded OME-Zarr 0.5 directly
- \`_TensorStoreWriteAdapter\` routes writes through tensorstore (zarr-python 3.1's sharding codec silently loses partial-shard writes; tensorstore handles them correctly)
- Per-position tensorstore Transaction coalesces 2704 X-block writes into one re-encode per shard at commit (970 s drain → ~10-50 s commits)
- iohub codec patch: \`STITCH_V3_CODEC=lz4\` / \`=none\` env override (default zstd)

### shard_stripes parallel mode
- Partitions each well's output along shard cell rows (must snap to shard cells — chunk-aligned doesn't work because multiple stripes writing into the same shard race)
- Workers run in spawn-mode child processes, each with its own CUDA context and tensorstore handle
- Workers bypass iohub for navigation (\`_StripePositionStub\`); parent pre-creates plate/position/array so iohub-managed multiscales metadata is written correctly
- Tunable via \`STITCH_STRIPES_PER_WELL\` (default 4) and \`STITCH_STRIPE_WORKERS\` (default 6)
- **Auto mode**: \`parallel_mode=\"auto\"\` now picks \`shard_stripes\` when zarr_version=\"0.5\". v2 callers keep the legacy dask_wells/thread_wells path.

### NFS fanout caps for multi-worker mode
- 4 workers × 8 prefetch threads × 16 inner per-band loaders = 512 concurrent NFS reads, which wedges the NFS mount (workers stick in D-state, same failure mode as organelle Pass 1)
- Worker init defaults: \`STITCH_PIPELINE_WORKERS=2\`, \`STITCH_PREFETCH_DEPTH=2\`, \`STITCH_INNER_LOAD_THREADS=4\` → ~32 concurrent reads

### Auto-sized tensorstore concurrency
- Default \`data_copy_concurrency=32\` × \`file_io_concurrency=16\` per handle × N workers oversubscribes the cgroup during commit
- Worker init computes per-worker share: \`SLURM_CPUS_PER_TASK / N_workers\` for data_copy, half that for file_io
- Operators can override either env var explicitly

### Misc
- \`STITCH_PARALLEL_MODE\` env override (production CLI doesn't take parallel_mode in its signature)
- \`STITCH_TS_CACHE_BYTES\` (default 2 GB) bounds the tensorstore decode cache pool (was unbounded)
- \`_maybe_free_pool\` gate keeps CuPy pool warm by default (saves 200-800 ms alloc per band); operators opt into eager freeing via \`STITCH_FREE_POOL_PER_BAND=1\`

## Companion PRs

- **ops_utils** (czbiohub-sf/ops_utils#11): \`@notify_step\` decorator now aggregates CPU/memory across the whole subprocess tree (fixes parent-only metrics for multiprocess workloads)
- **ops_process** (royerlab/ops_process#96): defaults \`estimate_and_stitch\` to v3 (\`zarr_version=\"0.5\"\`)

## Test plan

- [x] Synth bench bit-identical to V2 (multiple runs)
- [x] Real bench (3 wells, 370 GB) bit-identical, n=5 reproducibility (mean ~330 s, range 271-346)
- [x] Production CLI run via \`estimate_and_stitch\` (271 s, slice equal True, OME-NGFF metadata valid)
- [x] No NFS wedge on previously-affected nodes (fanout cap fix verified on gpu-h-4)
- [x] Memory peak 411 GB on real bench, fits --mem=450G
- [x] v2 path unchanged when \`zarr_version=\"0.4\"\` is explicitly passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## End-to-end validation

This PR was validated as part of the three-PR v3-native stitch phase. Full end-to-end run on `ops0146_20260402` (45-step DAG) plus correctness comparison vs Gav's reference run (gene-call agreement, SCIP/Gurobi caveat, per-artifact pearson/agreement table) is described in detail in **royerlab/ops_process#96**.
