### PR TITLE
v3 stitching changes (zarr-3 / iohub-0.3.7 stack)

### DIFF
--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -694,11 +694,13 @@ def assemble_streaming(
     if profile:
         print(f"[assemble.streaming] PROFILING ENABLED (GPU syncs will slow overall runtime)")
 
-    # Read tile shapes directly from .zarray JSON files (avoids opening full HCS store).
+    # Read tile shapes directly from array JSON files (avoids opening full HCS store).
     fov_store_p = Path(fov_store_path)
     tile_shapes = {}
     for tname in shifts.keys():
-        with open(fov_store_p / tname / "0" / ".zarray") as f:
+        arr_dir = fov_store_p / tname / "0"
+        arr_meta_path = arr_dir / "zarr.json" if (arr_dir / "zarr.json").exists() else arr_dir / ".zarray"
+        with open(arr_meta_path) as f:
             meta = json.load(f)
         tile_shapes[tname] = tuple(meta["shape"])
 
@@ -1399,15 +1401,31 @@ def stitch(
     # takes minutes; reading one position's JSON files is instant.
     input_store_p = Path(input_store_path)
     first_pos_key = next(iter(all_shifts.keys()))  # e.g. "A/1/002026"
-    with open(input_store_p / first_pos_key / ".zattrs") as f:
-        pos_attrs = json.load(f)
-    channel_names = [c["label"] for c in pos_attrs["omero"]["channels"]]
-    scale_transforms = pos_attrs.get("multiscales", [{}])[0].get("datasets", [{}])[0].get("coordinateTransformations", [])
+    ngff_version = kwargs.get("ngff_version", "0.4")
+    if ngff_version == "0.5":
+        with open(input_store_p / first_pos_key / "zarr.json") as f:
+            raw = json.load(f)
+        pos_attrs = raw.get("attributes", raw)
+    else:
+        with open(input_store_p / first_pos_key / ".zattrs") as f:
+            pos_attrs = json.load(f)
+    if ngff_version == "0.5":
+        channel_names = [c["label"] for c in pos_attrs["ome"]["omero"]["channels"]]
+        scale_transforms = pos_attrs.get("ome", {}).get("multiscales", [{}])[0].get("datasets", [{}])[0].get("coordinateTransformations", [])
+    else:
+        channel_names = [c["label"] for c in pos_attrs["omero"]["channels"]]
+        scale_transforms = pos_attrs.get("multiscales", [{}])[0].get("datasets", [{}])[0].get("coordinateTransformations", [])
     scale = tuple(scale_transforms[0]["scale"]) if scale_transforms and scale_transforms[0].get("type") == "scale" else None
-    with open(input_store_p / first_pos_key / "0" / ".zarray") as f:
-        arr_meta = json.load(f)
-    tile_shape = tuple(arr_meta["shape"])
-    chunks_size = tuple(arr_meta["chunks"])
+    if ngff_version == "0.5":
+        with open(input_store_p / first_pos_key / "0" / "zarr.json") as f:
+            arr_meta = json.load(f)
+        tile_shape = tuple(arr_meta["shape"])
+        chunks_size = tuple(arr_meta["chunk_grid"]["configuration"]["chunk_shape"])
+    else:
+        with open(input_store_p / first_pos_key / "0" / ".zarray") as f:
+            arr_meta = json.load(f)
+        tile_shape = tuple(arr_meta["shape"])
+        chunks_size = tuple(arr_meta["chunks"])
     # Optional override for output chunking to improve viewer (dask/napari) responsiveness
     # Accept either full 5D "target_chunks" or YX-only via "target_chunks_yx"
     target_chunks = kwargs.get("target_chunks")
@@ -1493,8 +1511,12 @@ def stitch(
 
             # Determine T,C,Z from tile metadata
             first_tile_key = next(iter(well_shifts.keys()))
-            with open(fov_store_p / first_tile_key / "0" / ".zarray") as f:
-                meta = json.load(f)
+            if ngff_version == "0.5":
+                with open(fov_store_p / first_tile_key / "0" / "zarr.json") as f:
+                    meta = json.load(f)
+            else:
+                with open(fov_store_p / first_tile_key / "0" / ".zarray") as f:
+                    meta = json.load(f)
             first_tile_shape = tuple(meta["shape"])
             final_shape = first_tile_shape[:3] + final_shape_xy
 
@@ -1538,8 +1560,12 @@ def stitch(
             dtype_idx = _resolve_shift_dtype(well_shifts, tile_shape[-2:], base_bits=32)
             tile_shapes = {}
             for tname in well_shifts.keys():
-                with open(fov_store_p / tname / "0" / ".zarray") as f:
-                    tmeta = json.load(f)
+                if ngff_version == "0.5":
+                    with open(fov_store_p / tname / "0" / "zarr.json") as f:
+                        tmeta = json.load(f)
+                else:
+                    with open(fov_store_p / tname / "0" / ".zarray") as f:
+                        tmeta = json.load(f)
                 tile_shapes[tname] = tuple(tmeta["shape"])
 
             tile_meta = []

--- a/stitch/stitch/assemble.py
+++ b/stitch/stitch/assemble.py
@@ -2385,6 +2385,13 @@ def stitch(
     input_store_p = Path(input_store_path)
     first_pos_key = next(iter(all_shifts.keys()))  # e.g. "A/1/002026"
     ngff_version = kwargs.get("ngff_version", "0.4")
+    # Validate once here so every `if ngff_version == "0.5": ... else: ...` block
+    # below is provably the 0.4 path in its `else` (an unexpected version fails
+    # loudly rather than silently taking the 0.4 branch).
+    if ngff_version not in ("0.4", "0.5"):
+        raise ValueError(
+            f"unsupported ngff_version {ngff_version!r}; expected '0.4' or '0.5'"
+        )
     if ngff_version == "0.5":
         with open(input_store_p / first_pos_key / "zarr.json") as f:
             raw = json.load(f)

--- a/stitch/stitch/tile.py
+++ b/stitch/stitch/tile.py
@@ -11,11 +11,20 @@ import scipy
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from dexp.processing.registration.model.translation_registration_model import (
-    TranslationRegistrationModel,
-)
-from dexp.processing.registration import translation_nd as dexp_reg
-from dexp.processing.utils.linear_solver import linsolve
+# dexp pulls cupy (GPU); it's optional at IMPORT so this module loads in dexp-less
+# envs (e.g. downstream CI that imports the stitch package without GPU deps). The
+# names below are used only inside the GPU registration/solver functions
+# (register_translation_gpu, offset, optimal_positions), which run where dexp is present.
+try:
+    from dexp.processing.registration.model.translation_registration_model import (
+        TranslationRegistrationModel,
+    )
+    from dexp.processing.registration import translation_nd as dexp_reg
+    from dexp.processing.utils.linear_solver import linsolve
+except ModuleNotFoundError:
+    TranslationRegistrationModel = None
+    dexp_reg = None
+    linsolve = None
 from stitch.connect import parse_positions, pos_to_name
 from stitch.stitch.graph import connectivity, hilbert_over_points
 


### PR DESCRIPTION
Reconciles the `integration/nextflow` line (used to generate the ISS v3 reference run) onto `main`, carrying the `beta/nextflow_zarrv3_changes` work.

### Changes
- Uncommitted v3 stitching changes from `beta/nextflow_zarrv3_changes`.
- Merged `origin/main` cleanly; one conflict in `assemble.py` resolved as a **union** of two independent features: main's `force_yx_scale` YX-scale override + this branch's version-aware (`zarr.json` v0.5 / `.zarray`) array-metadata read.

### Validation
`assemble.stitch()` exposes both `ngff_version` (input read) and `zarr_version` (output format); compiles clean. Exercised via the downstream `ops_process` stitch stages.

Opened from a fork (read-only access to this repo).

---

### Relationship to #13 (Kevin Liu)
This branch is built directly on `beta/nextflow_zarrv3_changes`, so it **incorporates #13's work** (authorship preserved). His later commit `24f9c29` ("ngff version passdown") is intentionally **not carried forward** because it is superseded by main's version handling merged here:
- output store already opens with `version=zarr_version` (the deliberate output-format control), and
- `estimate_stitch()` opens the input with no explicit version; iohub auto-detects the NGFF version on read (verified against ops0161 v0.4 *and* v0.5 stores), so the explicit `version=` param is unnecessary here.

His intent (correct version passdown) is achieved by main's mechanism. #13 can be closed in favor of this PR.
